### PR TITLE
Move to pure Kotlin reflection

### DIFF
--- a/src/main/kotlin/kia/jkid/Util.kt
+++ b/src/main/kotlin/kia/jkid/Util.kt
@@ -1,19 +1,17 @@
 package kia.jkid
 
-import java.lang.reflect.ParameterizedType
-import java.lang.reflect.Type
-import kotlin.reflect.KAnnotatedElement
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
-
-fun Type.asJavaClass(): Class<Any> = when (this) {
-    is Class<*> -> this as Class<Any>
-    is ParameterizedType -> rawType as? Class<Any>
-            ?: throw UnsupportedOperationException("Unknown type $this")
-    else -> throw UnsupportedOperationException("Unknown type $this")
-}
-
-fun <T> Iterable<T>.joinToStringBuilder(stringBuilder: StringBuilder, separator: CharSequence = ", ", prefix: CharSequence = "", postfix: CharSequence = "", limit: Int = -1, truncated: CharSequence = "...", callback: ((T) -> Unit)? = null): StringBuilder {
+fun <T> Iterable<T>.joinToStringBuilder(
+    stringBuilder: StringBuilder,
+    separator: CharSequence = ", ",
+    prefix: CharSequence = "",
+    postfix: CharSequence = "",
+    limit: Int = -1,
+    truncated: CharSequence = "...",
+    callback: ((T) -> Unit)? = null
+): StringBuilder {
     return joinTo(stringBuilder, separator, prefix, postfix, limit, truncated) {
         if (callback == null) return@joinTo it.toString()
         callback(it)
@@ -21,7 +19,17 @@ fun <T> Iterable<T>.joinToStringBuilder(stringBuilder: StringBuilder, separator:
     }
 }
 
-fun Type.isPrimitiveOrString(): Boolean {
-    val cls = this as? Class<Any> ?: return false
-    return cls.kotlin.javaPrimitiveType != null || cls == String::class.java
+fun KType.isPrimitiveOrString(): Boolean {
+    val types = setOf(
+        typeOf<Byte>(),
+        typeOf<Short>(),
+        typeOf<Int>(),
+        typeOf<Long>(),
+        typeOf<Float>(),
+        typeOf<Double>(),
+        typeOf<Boolean>(),
+        typeOf<String>(),
+        typeOf<String?>(),
+    )
+    return this in types
 }

--- a/src/main/kotlin/kia/jkid/ValueSerializers.kt
+++ b/src/main/kotlin/kia/jkid/ValueSerializers.kt
@@ -1,23 +1,25 @@
 package kia.jkid
 
 import kia.jkid.deserialization.JKidException
-import java.lang.reflect.Type
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
-fun serializerForBasicType(type: Type): ValueSerializer<out Any?> {
-    assert(type.isPrimitiveOrString()) { "Expected primitive type or String: ${type.typeName}" }
+fun serializerForBasicType(type: KType): ValueSerializer<out Any?> {
+    assert(type.isPrimitiveOrString()) { "Expected primitive type or String: $type" }
     return serializerForType(type)!!
 }
 
-fun serializerForType(type: Type): ValueSerializer<out Any?>? =
+fun serializerForType(type: KType): ValueSerializer<out Any?>? =
         when (type) {
-            Byte::class.java, Byte::class.javaObjectType -> ByteSerializer
-            Short::class.java, Short::class.javaObjectType -> ShortSerializer
-            Int::class.java, Int::class.javaObjectType -> IntSerializer
-            Long::class.java, Long::class.javaObjectType -> LongSerializer
-            Float::class.java, Float::class.javaObjectType -> FloatSerializer
-            Double::class.java, Double::class.javaObjectType -> DoubleSerializer
-            Boolean::class.java, Boolean::class.javaObjectType -> BooleanSerializer
-            String::class.java -> StringSerializer
+            typeOf<Byte>() -> ByteSerializer
+            typeOf<Short>() -> ShortSerializer
+            typeOf<Int>() -> IntSerializer
+            typeOf<Long>() -> LongSerializer
+            typeOf<Float>() -> FloatSerializer
+            typeOf<Double>() -> DoubleSerializer
+            typeOf<Boolean>() -> BooleanSerializer
+            typeOf<String>(),
+            typeOf<String?>() -> StringSerializer
             else -> null
         }
 

--- a/src/main/kotlin/kia/jkid/deserialization/ClassInfoCache.kt
+++ b/src/main/kotlin/kia/jkid/deserialization/ClassInfoCache.kt
@@ -3,8 +3,8 @@ package kia.jkid.deserialization
 import kia.jkid.DeserializeInterface
 import kia.jkid.JsonName
 import kia.jkid.ValueSerializer
-import kia.jkid.serializerForType
 import kia.jkid.serialization.getSerializer
+import kia.jkid.serializerForType
 import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.declaredMemberProperties
@@ -27,7 +27,7 @@ class ClassInfo<T : Any>(cls: KClass<T>) {
 
     private val jsonNameToParamMap = hashMapOf<String, KParameter>()
     private val paramToSerializerMap = hashMapOf<KParameter, ValueSerializer<out Any?>>()
-    private val jsonNameToDeserializeClassMap = hashMapOf<String, Class<out Any>?>()
+    private val jsonNameToDeserializeClassMap = hashMapOf<String, KClass<out Any>?>()
 
     init {
         constructor.parameters.forEach { cacheDataForParameter(cls, it) }
@@ -41,11 +41,11 @@ class ClassInfo<T : Any>(cls: KClass<T>) {
         val name = property.findAnnotation<JsonName>()?.name ?: paramName
         jsonNameToParamMap[name] = param
 
-        val deserializeClass = property.findAnnotation<DeserializeInterface>()?.targetClass?.java
+        val deserializeClass = property.findAnnotation<DeserializeInterface>()?.targetClass
         jsonNameToDeserializeClassMap[name] = deserializeClass
 
         val valueSerializer = property.getSerializer()
-                ?: serializerForType(param.type.javaType)
+            ?: serializerForType(param.type)
                 ?: return
         paramToSerializerMap[param] = valueSerializer
     }
@@ -64,6 +64,7 @@ class ClassInfo<T : Any>(cls: KClass<T>) {
     }
 
     private fun validateArgumentType(param: KParameter, value: Any?) {
+        println("Validating $param with value $value")
         if (value == null && !param.type.isMarkedNullable) {
             throw JKidException("Received null value for non-null parameter ${param.name}")
         }


### PR DESCRIPTION
Move from Java Type to Kotlin KType, use typeOf instead of relying on `javaPrimitiveType`. Proper handling of generic types via `starProjectedType` and new subtype / parametrized type helper functions.